### PR TITLE
Set initial SP to the end of the RAM

### DIFF
--- a/main.c
+++ b/main.c
@@ -100,6 +100,8 @@ void init_cpu(struct cpu *c){
     for(int i=0;i<16;i++){
         c->reg[i] = 0;
     }
+    // Set initial SP to the end of the RAM.
+    c->reg[1] = DATA_RAM_SIZE - 2;
     for(int i=0;i<INST_ROM_SIZE;i++){
         c->inst_rom[i] = 0;
     }


### PR DESCRIPTION
In RV16Kv2 the stack grows downward, so the initial value of SP shouldn't be 0.