### PR TITLE
Do not load BSS section directly

### DIFF
--- a/elf_parser.c
+++ b/elf_parser.c
@@ -81,6 +81,12 @@ void elf_parse(struct cpu *c, char* file_name){
             uint8_t *obj = (uint8_t *)(file_buffer+Shdr[i].sh_offset);
             uint8_t data_ram_offset = Shdr[i].sh_addr & 0x0000ffff;
 
+            if (strcmp(".bss", name) == 0) {
+                // .bss section shouldn't be loaded to RAM, but be placed after all other sections.
+                // FIXME: Check if this sections is placed after all other sections.
+                continue;
+            }
+
             for(int j=0;j<Shdr[i].sh_size;j+=2){
                 printf("RAM: %04X %02X%02X\n", data_ram_offset + j, obj[j], obj[j+1]);
                 c->data_ram[data_ram_offset+ j] = obj[j];


### PR DESCRIPTION
BSS (`.bss`) section doesn't have initial values, so we shouldn't load it to RAM. Instead, necessary space for it will be allocated at link time by placing `.bss` after all sections, which will give it the remaining RAM space that no section will use.