### PR TITLE
Use getopt to handle options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-main: main.c elf_parser.c bitpat.c
-	gcc -o main main.c elf_parser.c bitpat.c
+main: main.c elf_parser.c bitpat.c log.c
+	gcc -o $@ $^
 clean:
 	rm main
 test:

--- a/elf_parser.c
+++ b/elf_parser.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
+#include "log.h"
 #include "elf.h"
 #include "cpu.h"
 
@@ -16,13 +17,13 @@ void elf_parse(struct cpu *c, char* file_name){
     uint8_t* file_buffer;
 
     if(stat(file_name, &st) != 0){
-        printf("Failed to get file size :%s\n", file_name);
+        log_printf("Failed to get file size :%s\n", file_name);
         exit(1);
     }
     file_size = st.st_size;
 
     if((fp = fopen(file_name, "rb")) == NULL){
-        printf("Failed to open file :%s\n", file_name);
+        log_printf("Failed to open file :%s\n", file_name);
         exit(1);
     }
 
@@ -30,25 +31,25 @@ void elf_parse(struct cpu *c, char* file_name){
 
     int load_size = fread(file_buffer, sizeof(uint8_t), file_size, fp);
     if(load_size != file_size){
-        printf("File size is not matched: %s\n", file_name);
+        log_printf("File size is not matched: %s\n", file_name);
         exit(1);
     }
 #ifdef DEBUG
-    printf("Loaded File: %s (%dbyte)\n", file_name, load_size);
+    log_printf("Loaded File: %s (%dbyte)\n", file_name, load_size);
 #endif
 
     Elf32_Ehdr *Ehdr = (Elf32_Ehdr *)file_buffer;
     if(!IS_ELF(*Ehdr)){
-        printf("Unkown file format\n");
+        log_printf("Unkown file format\n");
         exit(1);
     }
     if(!IS_ELF32(*Ehdr)){
-        printf("Not ELF32 format\n");
+        log_printf("Not ELF32 format\n");
         exit(1);
     }
 #ifdef DEBUG
-    printf("Type:ELF32\n");
-    printf("Entry point:%d\n\n", Ehdr->e_entry);
+    log_printf("Type:ELF32\n");
+    log_printf("Entry point:%d\n\n", Ehdr->e_entry);
 #endif
 
     Elf32_Shdr *Shdr = (Elf32_Shdr *)(file_buffer + Ehdr->e_shoff);
@@ -56,13 +57,13 @@ void elf_parse(struct cpu *c, char* file_name){
     for(int i=0; i<Ehdr->e_shnum;i++){
         char *name = &shstr[Shdr[i].sh_name];
 #ifdef DEBUG
-        printf("Shdr:%d sh_name:%s\n", i, &shstr[Shdr[i].sh_name]);
-        printf("Shdr:%d sh_type:%04X\n", i, Shdr[i].sh_type);
-        printf("Shdr:%d sh_flags:%04X\n", i, Shdr[i].sh_flags);
-        printf("Shdr:%d sh_addr:%04X\n", i, Shdr[i].sh_addr);
-        printf("Shdr:%d sh_offset:%04X\n", i, Shdr[i].sh_offset);
-        printf("Shdr:%d sh_size:%04X\n", i, Shdr[i].sh_size);
-        puts("");
+        log_printf("Shdr:%d sh_name:%s\n", i, &shstr[Shdr[i].sh_name]);
+        log_printf("Shdr:%d sh_type:%04X\n", i, Shdr[i].sh_type);
+        log_printf("Shdr:%d sh_flags:%04X\n", i, Shdr[i].sh_flags);
+        log_printf("Shdr:%d sh_addr:%04X\n", i, Shdr[i].sh_addr);
+        log_printf("Shdr:%d sh_offset:%04X\n", i, Shdr[i].sh_offset);
+        log_printf("Shdr:%d sh_size:%04X\n", i, Shdr[i].sh_size);
+        log_printf("\n");
 #endif
 
         if (strcmp(".text", name) == 0) {   // ROM
@@ -73,11 +74,11 @@ void elf_parse(struct cpu *c, char* file_name){
             for(int j=0;j<Shdr[i].sh_size;j+=2){
                 assert(j + 1 < INST_ROM_SIZE && "Too large program (.text) data.");
 
-                printf("ROM: %04X %02X%02X\n", j, obj[j], obj[j+1]);
+                log_printf("ROM: %04X %02X%02X\n", j, obj[j], obj[j+1]);
                 c->inst_rom[j] = obj[j];
                 c->inst_rom[j+1] = obj[j+1];
             }
-            puts("");
+            log_printf("\n");
         }
         else if (0x00010000 <= Shdr[i].sh_addr && Shdr[i].sh_addr <= 0x0001ffff) {  // RAM
             uint8_t *obj = (uint8_t *)(file_buffer+Shdr[i].sh_offset);
@@ -92,11 +93,11 @@ void elf_parse(struct cpu *c, char* file_name){
             for(int j=0;j<Shdr[i].sh_size;j+=2){
                 assert(data_ram_offset + j + 1 < DATA_RAM_SIZE && "Too large data (.data/.rodata).");
 
-                printf("RAM: %04X %02X%02X\n", data_ram_offset + j, obj[j], obj[j+1]);
+                log_printf("RAM: %04X %02X%02X\n", data_ram_offset + j, obj[j], obj[j+1]);
                 c->data_ram[data_ram_offset+ j] = obj[j];
                 c->data_ram[data_ram_offset+ j+1] = obj[j+1];
             }
-            puts("");
+            log_printf("\n");
         }
     }
 

--- a/log.c
+++ b/log.c
@@ -1,0 +1,14 @@
+#include "error.h"
+#include <stdarg.h>
+#include <stdio.h>
+
+int flag_quiet = 0;
+
+void log_printf(char *fmt, ...) {
+    if (flag_quiet) return;
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+}

--- a/log.h
+++ b/log.h
@@ -1,0 +1,7 @@
+#pragma once
+#ifndef ERROR_H
+#define ERROR_H
+
+void log_printf(char *fmt, ...);
+
+#endif

--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,7 @@ failwith() {
 }
 
 testentry() {
-    res=$(./main "test" "$2" "$3" "$1")
+    res=$(./main -q -t "$2" -d "$3" "$1")
     echo "$res" | grep "$4" > /dev/null
     [ "$?" -eq 0 ] || failwith "$1" "$2" "$3" "$4" "$res"
 }


### PR DESCRIPTION
Now everything should work fine with this PR! We use `getopt` to handle many options to rv16k-sim, but its basic usage doesn't change; when we want to run some RV16K binary, just type `/path/to/rv16k-sim/main program.exe 100`, and that's all. Many options will be used mainly for tests or debugs.